### PR TITLE
Enable more compiler warnings, treat warnings as errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,31 @@ dependencies {
     simulation wpi.deps.sim.gui(wpi.platforms.desktop, true)
 }
 
+/*
+ * Customize the compiler arguments to enable more warninngs and treat them as errors.
+ *
+ * Currently only being done when compiling for the roboRIO (e.g. not desktop builds such as simulation).
+ *
+ * See below for the default arguments being used:
+ * https://github.com/wpilibsuite/native-utils/blob/2d6004c36a850ca3121468dcc003c38e23fa9b7e/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java#L48-L53
+ * https://github.com/wpilibsuite/native-utils/blob/2d6004c36a850ca3121468dcc003c38e23fa9b7e/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java#L118-L119
+ */
+nativeUtils {
+    platformConfigs {
+        linuxathena {
+            // Default includes '-Wformat=2', '-pedantic', '-Wno-psabi', '-Wno-unused-parameter', '-Wno-error=deprecated-declarations'
+            cppCompiler.args.removeAll { arg -> arg.startsWith('-W') }
+            cppCompiler.args.remove('-pedantic')
+            cppCompiler.args.addAll(['-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wformat=2'])
+
+            // Default includes '-Wformat=2', '-pedantic', '-Wno-psabi', '-Wno-unused-parameter'
+            cCompiler.args.removeAll { arg -> arg.startsWith('-W') }
+            cCompiler.args.remove('-pedantic')
+            cCompiler.args.addAll(['-Werror', '-Wall', '-Wextra', '-Wpedantic', '-Wformat=2'])
+        }
+    }
+}
+
 model {
     components {
         frcUserProgram(NativeExecutableSpec) {


### PR DESCRIPTION
@intimitrons4604/programmingteam 

Enable more compiler warnings, and treat all warnings as errors (i.e. the code will not build unless there are zero warnings).

- The warnings are currently only enabled when building for the roboRIO, and not for simulation of the robot code on a laptop for example.
- These warnings help you catch mistakes, like forgetting to `return` a value from a function, and overall lead to better quality and more maintainable code.
- If you want to read about the warnings and these options, see https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html