### PR TITLE
Add clang-format configuration and reformat code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,69 @@
+---
+BasedOnStyle: Chromium
+AccessModifierOffset: '-2'
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignEscapedNewlines: Left
+AlignOperands: 'false'
+AlignTrailingComments: 'false'
+AllowAllParametersOfDeclarationOnNextLine: 'true'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: 'true'
+BinPackArguments: 'true'
+BinPackParameters: 'true'
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: 'true'
+BreakBeforeTernaryOperators: 'false'
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: 'false'
+ColumnLimit: '120'
+CompactNamespaces: 'false'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'false'
+ConstructorInitializerIndentWidth: '4'
+ContinuationIndentWidth: '2'
+Cpp11BracedListStyle: 'true'
+DerivePointerAlignment: 'true'
+FixNamespaceComments: 'true'
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<(FRC_FPGA_ChipObject|FRC_NetworkCommunication|cameraserver|frc|frc2|hal|mockdata|networktables|simulation|tables|units|visa|vision|wpi)\/'
+    Priority: 2
+  - Regex: '^<.*'
+    Priority: 1
+  - Regex: '^".*'
+    Priority: 3
+IndentCaseLabels: 'true'
+IndentPPDirectives: AfterHash
+IndentWidth: '2'
+IndentWrappedFunctionNames: 'true'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+NamespaceIndentation: None
+PointerAlignment: Left
+ReflowComments: 'true'
+SortIncludes: 'true'
+SortUsingDeclarations: 'true'
+SpaceAfterCStyleCast: 'true'
+SpaceAfterTemplateKeyword: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: 'false'
+SpacesBeforeTrailingComments: '1'
+SpacesInAngles: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: Cpp11
+TabWidth: '2'
+UseTab: Never
+...

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -10,7 +10,9 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <frc2/command/CommandScheduler.h>
 
-void Robot::RobotInit() {}
+void Robot::RobotInit()
+{
+}
 
 /**
  * This function is called every robot packet, no matter the mode. Use
@@ -20,37 +22,50 @@ void Robot::RobotInit() {}
  * <p> This runs after the mode specific periodic functions, but before
  * LiveWindow and SmartDashboard integrated updating.
  */
-void Robot::RobotPeriodic() { frc2::CommandScheduler::GetInstance().Run(); }
+void Robot::RobotPeriodic()
+{
+  frc2::CommandScheduler::GetInstance().Run();
+}
 
 /**
  * This function is called once each time the robot enters Disabled mode. You
  * can use it to reset any subsystem information you want to clear when the
  * robot is disabled.
  */
-void Robot::DisabledInit() {}
+void Robot::DisabledInit()
+{
+}
 
-void Robot::DisabledPeriodic() {}
+void Robot::DisabledPeriodic()
+{
+}
 
 /**
  * This autonomous runs the autonomous command selected by your {@link
  * RobotContainer} class.
  */
-void Robot::AutonomousInit() {
+void Robot::AutonomousInit()
+{
   m_autonomousCommand = m_container.GetAutonomousCommand();
 
-  if (m_autonomousCommand != nullptr) {
+  if (m_autonomousCommand != nullptr)
+  {
     m_autonomousCommand->Schedule();
   }
 }
 
-void Robot::AutonomousPeriodic() {}
+void Robot::AutonomousPeriodic()
+{
+}
 
-void Robot::TeleopInit() {
+void Robot::TeleopInit()
+{
   // This makes sure that the autonomous stops running when
   // teleop starts running. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
-  if (m_autonomousCommand != nullptr) {
+  if (m_autonomousCommand != nullptr)
+  {
     m_autonomousCommand->Cancel();
     m_autonomousCommand = nullptr;
   }
@@ -59,13 +74,20 @@ void Robot::TeleopInit() {
 /**
  * This function is called periodically during operator control.
  */
-void Robot::TeleopPeriodic() {}
+void Robot::TeleopPeriodic()
+{
+}
 
 /**
  * This function is called periodically during test mode.
  */
-void Robot::TestPeriodic() {}
+void Robot::TestPeriodic()
+{
+}
 
 #ifndef RUNNING_FRC_TESTS
-int main() { return frc::StartRobot<Robot>(); }
+int main()
+{
+  return frc::StartRobot<Robot>();
+}
 #endif

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -7,18 +7,21 @@
 
 #include "RobotContainer.h"
 
-RobotContainer::RobotContainer() : m_autonomousCommand(&m_subsystem) {
+RobotContainer::RobotContainer() : m_autonomousCommand(&m_subsystem)
+{
   // Initialize all of your commands and subsystems here
 
   // Configure the button bindings
   ConfigureButtonBindings();
 }
 
-void RobotContainer::ConfigureButtonBindings() {
+void RobotContainer::ConfigureButtonBindings()
+{
   // Configure your button bindings here
 }
 
-frc2::Command* RobotContainer::GetAutonomousCommand() {
+frc2::Command* RobotContainer::GetAutonomousCommand()
+{
   // An example command will be run in autonomous
   return &m_autonomousCommand;
 }

--- a/src/main/cpp/commands/ExampleCommand.cpp
+++ b/src/main/cpp/commands/ExampleCommand.cpp
@@ -7,5 +7,6 @@
 
 #include "commands/ExampleCommand.h"
 
-ExampleCommand::ExampleCommand(ExampleSubsystem* subsystem)
-    : m_subsystem{subsystem} {}
+ExampleCommand::ExampleCommand(ExampleSubsystem* subsystem) : m_subsystem{subsystem}
+{
+}

--- a/src/main/cpp/subsystems/ExampleSubsystem.cpp
+++ b/src/main/cpp/subsystems/ExampleSubsystem.cpp
@@ -7,10 +7,12 @@
 
 #include "subsystems/ExampleSubsystem.h"
 
-ExampleSubsystem::ExampleSubsystem() {
+ExampleSubsystem::ExampleSubsystem()
+{
   // Implementation of subsystem constructor goes here.
 }
 
-void ExampleSubsystem::Periodic() {
+void ExampleSubsystem::Periodic()
+{
   // Implementation of subsystem periodic method goes here.
 }

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -12,8 +12,9 @@
 
 #include "RobotContainer.h"
 
-class Robot : public frc::TimedRobot {
- public:
+class Robot : public frc::TimedRobot
+{
+public:
   void RobotInit() override;
   void RobotPeriodic() override;
   void DisabledInit() override;
@@ -24,7 +25,7 @@ class Robot : public frc::TimedRobot {
   void TeleopPeriodic() override;
   void TestPeriodic() override;
 
- private:
+private:
   // Have it null by default so that if testing teleop it
   // doesn't have undefined behavior and potentially crash.
   frc2::Command* m_autonomousCommand = nullptr;

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -19,13 +19,14 @@
  * scheduler calls).  Instead, the structure of the robot (including subsystems,
  * commands, and button mappings) should be declared here.
  */
-class RobotContainer {
- public:
+class RobotContainer
+{
+public:
   RobotContainer();
 
   frc2::Command* GetAutonomousCommand();
 
- private:
+private:
   // The robot's subsystems and commands are defined here...
   ExampleSubsystem m_subsystem;
   ExampleCommand m_autonomousCommand;

--- a/src/main/include/commands/ExampleCommand.h
+++ b/src/main/include/commands/ExampleCommand.h
@@ -19,9 +19,9 @@
  * directly; this is crucially important, or else the decorator functions in
  * Command will *not* work!
  */
-class ExampleCommand
-    : public frc2::CommandHelper<frc2::CommandBase, ExampleCommand> {
- public:
+class ExampleCommand : public frc2::CommandHelper<frc2::CommandBase, ExampleCommand>
+{
+public:
   /**
    * Creates a new ExampleCommand.
    *
@@ -29,6 +29,6 @@ class ExampleCommand
    */
   explicit ExampleCommand(ExampleSubsystem* subsystem);
 
- private:
+private:
   ExampleSubsystem* m_subsystem;
 };

--- a/src/main/include/subsystems/ExampleSubsystem.h
+++ b/src/main/include/subsystems/ExampleSubsystem.h
@@ -9,8 +9,9 @@
 
 #include <frc2/command/SubsystemBase.h>
 
-class ExampleSubsystem : public frc2::SubsystemBase {
- public:
+class ExampleSubsystem : public frc2::SubsystemBase
+{
+public:
   ExampleSubsystem();
 
   /**
@@ -18,7 +19,7 @@ class ExampleSubsystem : public frc2::SubsystemBase {
    */
   void Periodic() override;
 
- private:
+private:
   // Components (e.g. motor controllers and sensors) should generally be
   // declared private and exposed only through public methods.
 };

--- a/src/test/cpp/main.cpp
+++ b/src/test/cpp/main.cpp
@@ -2,7 +2,8 @@
 
 #include "gtest/gtest.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
   HAL_Initialize(500, 0);
   ::testing::InitGoogleTest(&argc, argv);
   int ret = RUN_ALL_TESTS();


### PR DESCRIPTION
@intimitrons4604/programmingteam 

This adds a configuration file for clang-format, a tool for formatting code. In VS Code, use the key combination `Shift+Alt+F` on Windows to format the current file. There are also key combinations to only format the currently selected text, or you can always find the formatting commands in the command palette.

Formatting the code automatically is good because code looks consistent regardless of who is writing it, and you don't have to spend time nitpicking when a tool can automatically apply the same standard to all the code. While formatting might not seem important, it makes the code more readable and can help avoid difficult to spot or easy to make mistakes.

If you're interested, see https://clang.llvm.org/docs/ClangFormat.html.

As an aside (and reminder for me later), clang-format is packaged as part of the VS Code C/C++ extension (`ms-vscode.cpptools`). The extension packaged with the 2020 FRC tools contains `clang-format version 6.0.0 (tags/RELEASE_600/final)`.